### PR TITLE
fix: resolve uvx when using a git client or IDE

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,8 +8,16 @@ integration *FLAGS:
   uv run pytest tests -m integration {{FLAGS}}
 
 format:
-  uvx ruff check . --fix
-  uvx ruff format .
+  #!/usr/bin/env bash
+  UVX_PATH="$(which uvx)"
+
+  if [ -z "$UVX_PATH" ]; then
+    echo "[error]: unable to find uvx"
+    exit 1
+  fi
+  eval "$UVX_PATH ruff format ."
+  eval "$UVX_PATH ruff check . --fix"
+
 
 coverage *FLAGS:
   uv run coverage run -m pytest tests -m "not integration" {{FLAGS}}
@@ -37,6 +45,7 @@ install-hooks:
     echo "[error]: failed to create pre-commit hook at $HOOKS_DIR/pre-commit"
     exit 1
   fi
+  echo "installed pre-commit hook to $HOOKS_DIR"
   chmod +x "$HOOKS_DIR/pre-commit"
 
 ai-exchange-version:

--- a/justfile
+++ b/justfile
@@ -19,6 +19,25 @@ coverage *FLAGS:
 docs:
   uv sync && uv run mkdocs serve
 
+install-hooks:
+  #!/usr/bin/env bash
+  HOOKS_DIR="$(git rev-parse --git-path hooks)"
+
+  if [ ! -d "$HOOKS_DIR" ]; then
+    mkdir -p "$HOOKS_DIR"
+  fi
+
+  cat > "$HOOKS_DIR/pre-commit" <<EOF
+  #!/usr/bin/env bash
+
+  just format
+  EOF
+
+  if [ ! -f "$HOOKS_DIR/pre-commit" ]; then
+    echo "[error]: failed to create pre-commit hook at $HOOKS_DIR/pre-commit"
+    exit 1
+  fi
+  chmod +x "$HOOKS_DIR/pre-commit"
 
 ai-exchange-version:
   curl -s https://pypi.org/pypi/ai-exchange/json | jq -r .info.version


### PR DESCRIPTION
When using a client and/or IDE with `git` integration built in, it's difficult to see a failed `ruff` commands until _after_ a commit is pushed up. This change adds the ability to see those errors in your client and/or editors if you have the pre-commit hooks installed.

Note: This is purely opt-in (`just install-hooks`) and a user can bypass with `--no-verify` after it's installed. n.b. this pre-commit hook does have the potential to "lose" a commit message but many clients save the most recent commit (`.git/COMMIT_EDITMSG`) but this is generally a bug with the `git` client/implementation itself.

## git-fork
### Before
![image](https://github.com/user-attachments/assets/8b5ff650-e027-4e6f-9a41-c2f26357f021)

### After
![image](https://github.com/user-attachments/assets/3345e688-5a19-45be-8b37-7fcdde94027e)


## `lazygit`
![image](https://github.com/user-attachments/assets/95343d71-5f33-4b68-841c-6d48b3471b17)

