### PR TITLE
ci: add include-markdown for mkdocs

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mkdocs mkdocs-material
+        pip install mkdocs mkdocs-material mkdocs-include-markdown-plugin
 
     - name: Build the documentation
       run: mkdocs build


### PR DESCRIPTION
quick fix our github workflow

![image](https://github.com/user-attachments/assets/1f2dc5e6-dd8b-4c50-be85-a5fb02d7787a)

