### PR TITLE
docs: update links to exchange to the new location

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,4 +163,4 @@ def example_history(self):
     ...
 ```
 
-[exchange]: https://github.com/square/exchange
+[exchange]: https://github.com/block-open-source/goose/tree/main/packages/exchange

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 
 [issues]: https://github.com/block-open-source/goose/issues
 [goose-plugins]: https://github.com/block-open-source/goose-plugins
-[ai-exchange]: https://github.com/square/exchange
+[ai-exchange]: https://github.com/block-open-source/goose/tree/main/packages/exchange
 [developer]: src/goose/toolkit/developer.py
 [uv]: https://docs.astral.sh/uv/
 [ruff]: https://docs.astral.sh/ruff/

--- a/docs/plugins/providers.md
+++ b/docs/plugins/providers.md
@@ -11,4 +11,4 @@ Providers in Goose mean "LLM providers" that Goose can interact with. Providers 
 * Ollama
 * OpenAI
 
-[exchange-providers]: https://github.com/square/exchange/tree/main/src/exchange/providers
+[exchange-providers]: https://github.com/block-open-source/goose/tree/main/packages/exchange/src/exchange/providers


### PR DESCRIPTION
Update old square links to within the new goose location