### PR TITLE
fix: Update OpenAI pricing per https://openai.com/api/pricing/

### DIFF
--- a/src/goose/utils/_cost_calculator.py
+++ b/src/goose/utils/_cost_calculator.py
@@ -2,8 +2,9 @@ from typing import Optional
 from exchange.providers.base import Usage
 
 PRICES = {
-    "gpt-4o": (5.00, 15.00),
+    "gpt-4o": (2.50, 10.00),
     "gpt-4o-2024-08-06": (2.50, 10.00),
+    "gpt-4o-2024-05-13": (5.00, 15.00),
     "gpt-4o-mini": (0.150, 0.600),
     "gpt-4o-mini-2024-07-18": (0.150, 0.600),
     "o1-preview": (15.00, 60.00),

--- a/tests/utils/test_cost_calculator.py
+++ b/tests/utils/test_cost_calculator.py
@@ -1,13 +1,22 @@
+from unittest.mock import patch
+import pytest
 from goose.utils._cost_calculator import _calculate_cost, get_total_cost_message
 from exchange.providers.base import Usage
 
 
-def test_calculate_cost():
+@pytest.fixture
+def mock_prices():
+    prices = {"gpt-4o": (5.00, 15.00), "gpt-4o-mini": (0.150, 0.600)}
+    with patch("goose.utils._cost_calculator.PRICES", prices) as mock_prices:
+        yield mock_prices
+
+
+def test_calculate_cost(mock_prices):
     cost = _calculate_cost("gpt-4o", Usage(input_tokens=10000, output_tokens=600, total_tokens=10600))
     assert cost == 0.059
 
 
-def test_get_total_cost_message():
+def test_get_total_cost_message(mock_prices):
     message = get_total_cost_message(
         {
             "gpt-4o": Usage(input_tokens=10000, output_tokens=600, total_tokens=10600),
@@ -22,7 +31,7 @@ def test_get_total_cost_message():
     assert message == expected_message
 
 
-def test_get_total_cost_message_with_non_available_pricing():
+def test_get_total_cost_message_with_non_available_pricing(mock_prices):
     message = get_total_cost_message(
         {
             "non_pricing_model": Usage(input_tokens=10000, output_tokens=600, total_tokens=10600),


### PR DESCRIPTION
Update the pricing for the main gpt-4o models after the last update.

See https://openai.com/api/pricing/ for confirmation.