### PR TITLE
fix: Set default model configuration for the Google provider.

### DIFF
--- a/docs/plugins/providers.md
+++ b/docs/plugins/providers.md
@@ -8,6 +8,7 @@ Providers in Goose mean "LLM providers" that Goose can interact with. Providers 
 * Azure
 * Bedrock
 * Databricks
+* Google
 * Ollama
 * OpenAI
 

--- a/src/goose/cli/config.py
+++ b/src/goose/cli/config.py
@@ -102,6 +102,7 @@ def default_model_configuration() -> Tuple[str, str, str]:
             "databricks-meta-llama-3-1-70b-instruct",
             "databricks-meta-llama-3-1-70b-instruct",
         ),
+        "google": ("gemini-1.5-flash", "gemini-1.5-flash"),
     }
     processor, accelerator = recommended.get(provider, ("gpt-4o", "gpt-4o-mini"))
     return provider, processor, accelerator


### PR DESCRIPTION
Set default model configuration for the Google provider. This enables a working configuration just by specifying `GOOGLE_API_KEY`. Without this PR, the configuration defaults to OpenAI processor and accelerator values, which do not work for the Google provider.

I set it to use the flash version for both the processor and accelerator. The free tier allows 15 requests per minute for flash, but only 2 requests per minute for pro.

Also add Google to the list of providers. 

Relevant issue: #129