### PR TITLE
fix: use concrete SessionNotifier

### DIFF
--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -13,7 +13,7 @@ from goose._logger import get_logger, setup_logging
 from goose.cli.config import LOG_PATH, ensure_config, session_path
 from goose.cli.prompt.goose_prompt_session import GoosePromptSession
 from goose.cli.prompt.overwrite_session_prompt import OverwriteSessionPrompt
-from goose.notifier import Notifier
+from goose.cli.session_notifier import SessionNotifier
 from goose.profile import Profile
 from goose.utils import droid, load_plugins
 from goose.utils._cost_calculator import get_total_cost_message
@@ -71,7 +71,7 @@ class Session:
         self.profile_name = profile
         self.prompt_session = GoosePromptSession()
         self.status_indicator = Status("", spinner="dots")
-        self.notifier = Notifier(self.status_indicator)
+        self.notifier = SessionNotifier(self.status_indicator)
 
         self.exchange = create_exchange(profile=load_profile(profile), notifier=self.notifier)
         setup_logging(log_file_directory=LOG_PATH, log_level=log_level)

--- a/tests/cli/test_session.py
+++ b/tests/cli/test_session.py
@@ -23,7 +23,7 @@ def create_session_with_mock_configs(mock_sessions_path, exchange_factory, profi
     with (
         patch("goose.cli.session.create_exchange") as mock_exchange,
         patch("goose.cli.session.load_profile", return_value=profile_factory()),
-        patch("goose.cli.session.Notifier") as mock_session_notifier,
+        patch("goose.cli.session.SessionNotifier") as mock_session_notifier,
         patch("goose.cli.session.load_provider", return_value="provider"),
     ):
         mock_session_notifier.return_value = MagicMock()


### PR DESCRIPTION
corrects a small error in merge conflict i made in [e6a428c](https://github.com/block-open-source/goose/pull/101/commits/e6a428cda5f13d354c28f32cf151a2861340e9c0). 

couldn't find any instantiation tests which would've caught this so will follow up with something so we can check in ci