### PR TITLE
fix: update summarizer_exchange model to use default model from input exchange

### DIFF
--- a/packages/exchange/src/exchange/moderators/summarizer.py
+++ b/packages/exchange/src/exchange/moderators/summarizer.py
@@ -25,7 +25,7 @@ class ContextSummarizer(ContextTruncate):
         summarizer_exchange = exchange.replace(
             system=Message.load("summarizer.jinja").text,
             moderator=PassiveModerator(),
-            model=self.model,
+            model=self.model if self.model else exchange.model,
             messages=messages_to_summarize,
             checkpoint_data=CheckpointData(),
         )


### PR DESCRIPTION
This PR fixes a bug with the Summarizer moderator in exchange where the Summarizer would default to using a None model when not passed in. This is updated to use the exchange's model if one is not passed as a parameter to the moderator.