### PR TITLE
docs: add subheaders to the 'Other ways to run Goose' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,12 @@ We have some experimental IDE integrations for VSCode and JetBrains IDEs:
 * https://github.com/square/goose-vscode
 * https://github.com/Kvadratni/goose-intellij
 
-There is also an experimental github action to run goose as part of your workflow (for example if you ask it to fix an issue): 
+**Goose as a Github Action**
+
+There is also an experimental Github action to run goose as part of your workflow (for example if you ask it to fix an issue): 
 https://github.com/marketplace/actions/goose-ai-developer-agent
+
+**With Docker**
 
 There is also a `Dockerfile` in the root of this project you can use if you want to run goose in a sandboxed fashion.
 


### PR DESCRIPTION
Called visual attention to the Github action and dockerfile in the **Other ways to run Goose** section