### PR TITLE
fix: Remove tools from exchange when summarizing files

### DIFF
--- a/src/goose/toolkit/repo_context/repo_context.py
+++ b/src/goose/toolkit/repo_context/repo_context.py
@@ -101,8 +101,9 @@ class RepoContext(Toolkit):
         file_select_exchange = replace_prompt(exchange=file_select_exchange, prompt=system)
         files = goose_picks_files(root=project_directory, exchange=file_select_exchange)
 
+        # summarize the selected files using a blank exchange with no tools
         summary = summarize_files_concurrent(
-            exchange=self.exchange_view.accelerator, file_list=files, project_name=project_directory.split("/")[-1]
+            exchange=clear_exchange(self.exchange_view.accelerator, clear_tools=True), file_list=files, project_name=project_directory.split("/")[-1]
         )
 
         return summary

--- a/src/goose/toolkit/repo_context/repo_context.py
+++ b/src/goose/toolkit/repo_context/repo_context.py
@@ -105,7 +105,7 @@ class RepoContext(Toolkit):
         summary = summarize_files_concurrent(
             exchange=clear_exchange(self.exchange_view.accelerator, clear_tools=True),
             file_list=files,
-            project_name=project_directory.split("/")[-1]
+            project_name=project_directory.split("/")[-1],
         )
 
         return summary

--- a/src/goose/toolkit/repo_context/repo_context.py
+++ b/src/goose/toolkit/repo_context/repo_context.py
@@ -103,7 +103,9 @@ class RepoContext(Toolkit):
 
         # summarize the selected files using a blank exchange with no tools
         summary = summarize_files_concurrent(
-            exchange=clear_exchange(self.exchange_view.accelerator, clear_tools=True), file_list=files, project_name=project_directory.split("/")[-1]
+            exchange=clear_exchange(self.exchange_view.accelerator, clear_tools=True),
+            file_list=files,
+            project_name=project_directory.split("/")[-1]
         )
 
         return summary


### PR DESCRIPTION
In the `repo_context` toolkit, Goose summarizes a list of files with the `summarize_files_concurrent` function. This function needs an exchange to work, and we were using the accelerator exchange for this. I found that because that exchange still had the `patch_file` tool, sometimes it would try to use it for single files and it would save the file summary to `path/to/file.txt` (literally). This PR removes tools from the 'blank' exchange we are using to summarize files. 