### PR TITLE
chore: restrict python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "goose-ai"
 description = "a programming agent that runs on your machine"
 version = "0.9.5"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10, <=3.12"
 dependencies = [
     "ai-exchange",
     "attrs>=23.2.0",


### PR DESCRIPTION
python 3.13 seems to have introduced changes that some packages haven't
been able to keep up with. we should restrict the latest until we've had
adequate time for it to bake.

adds compatibility: #154
fixes: #156

```
$ uv sync --index-url https://pypi.org/simple
Resolved 102 packages in 543ms
error: Failed to prepare distributions
  Caused by: Failed to fetch wheel: greenlet==3.0.3
  Caused by: Build backend failed to build wheel through `build_wheel()` with exit status: 1
```

```
error: Failed to prepare distributions
  Caused by: Failed to fetch wheel: tiktoken==0.7.0
  Caused by: Build backend failed to build wheel through `build_wheel()` with exit status: 1
```