### PR TITLE
fix: correct min/max supported python versions

### DIFF
--- a/packages/exchange/pyproject.toml
+++ b/packages/exchange/pyproject.toml
@@ -3,7 +3,7 @@ name = "ai-exchange"
 version = "0.9.6"
 description = "a uniform python SDK for message generation with LLMs"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.13"
 author = [{ name = "Block", email = "ai-oss-tools@block.xyz" }]
 packages = [{ include = "exchange", from = "src" }]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "goose-ai"
 description = "a programming agent that runs on your machine"
 version = "0.9.6"
 readme = "README.md"
-requires-python = ">=3.10, <=3.12"
+requires-python = ">=3.10, <3.13"
 dependencies = [
     "ai-exchange",
     "attrs>=23.2.0",


### PR DESCRIPTION
in #162, the python versions are overly restrictive and didn't factor in patch versions. as such, we want to relax this a bit more and i also missed the upgrade for `tiktoken==0.7.0` (which isn't compatible with python3.13) so this address that as well.