### PR TITLE
fix: added specific ai-exchange version and check path is None to avoid error after starting goose

### DIFF
--- a/packages/exchange/pyproject.toml
+++ b/packages/exchange/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-exchange"
-version = "0.9.7"
+version = "0.9.8"
 description = "a uniform python SDK for message generation with LLMs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/exchange/src/exchange/langfuse_wrapper.py
+++ b/packages/exchange/src/exchange/langfuse_wrapper.py
@@ -48,7 +48,7 @@ def auth_check() -> bool:
 CURRENT_DIR = Path(__file__).parent
 PACKAGE_ROOT = find_package_root(CURRENT_DIR)
 
-LANGFUSE_ENV_FILE = os.path.join(PACKAGE_ROOT, ".env.langfuse.local1") if PACKAGE_ROOT else None
+LANGFUSE_ENV_FILE = os.path.join(PACKAGE_ROOT, ".env.langfuse.local") if PACKAGE_ROOT else None
 HAS_LANGFUSE_CREDENTIALS = False
 load_dotenv(LANGFUSE_ENV_FILE, override=True)
 

--- a/packages/exchange/src/exchange/langfuse_wrapper.py
+++ b/packages/exchange/src/exchange/langfuse_wrapper.py
@@ -48,7 +48,7 @@ def auth_check() -> bool:
 CURRENT_DIR = Path(__file__).parent
 PACKAGE_ROOT = find_package_root(CURRENT_DIR)
 
-LANGFUSE_ENV_FILE = os.path.join(PACKAGE_ROOT, ".env.langfuse.local")
+LANGFUSE_ENV_FILE = os.path.join(PACKAGE_ROOT, ".env.langfuse.local1") if PACKAGE_ROOT else None
 HAS_LANGFUSE_CREDENTIALS = False
 load_dotenv(LANGFUSE_ENV_FILE, override=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "goose-ai"
 description = "a programming agent that runs on your machine"
-version = "0.9.7"
+version = "0.9.8"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "ai-exchange",
+    "ai-exchange=0.9.8",
     "attrs>=23.2.0",
     "rich>=13.7.1",
     "ruamel-yaml>=0.18.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.9.8"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "ai-exchange=0.9.8",
+    "ai-exchange",
     "attrs>=23.2.0",
     "rich>=13.7.1",
     "ruamel-yaml>=0.18.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.9.8"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "ai-exchange",
+    "ai-exchange==0.9.8",
     "attrs>=23.2.0",
     "rich>=13.7.1",
     "ruamel-yaml>=0.18.6",


### PR DESCRIPTION
**Issue**
https://github.com/block-open-source/goose/issues/173

**What**
This is only an emergency fix to avoid errors when user starts `goose`.  Will apply a follow up fix to load langfuse the environment variables properly

- Avoid loading the `None` path.  
- Specify the `ai-exchange` version