### PR TITLE
fix: Simplifed langfuse auth check

### DIFF
--- a/packages/exchange/.env.langfuse.local
+++ b/packages/exchange/.env.langfuse.local
@@ -9,8 +9,3 @@ LANGFUSE_INIT_USER_PASSWORD=localpwd
 LANGFUSE_INIT_ORG_ID=local-id
 LANGFUSE_INIT_ORG_NAME=local-org
 LANGFUSE_INIT_PROJECT_ID=goose
-
-# These variables are used by Goose
-LANGFUSE_PUBLIC_KEY=publickey-local
-LANGFUSE_SECRET_KEY=secretkey-local
-LANGFUSE_HOST=http://localhost:3000

--- a/packages/exchange/src/exchange/langfuse_wrapper.py
+++ b/packages/exchange/src/exchange/langfuse_wrapper.py
@@ -17,8 +17,10 @@ from typing import Callable
 from langfuse.decorators import langfuse_context
 import sys
 from io import StringIO
-from functools import cache, wraps  # Add this import
+from functools import cache, wraps
 
+## These are the default configurations for local Langfuse server
+## Please refer to .env.langfuse.local file for local langfuse server setup configurations
 DEFAULT_LOCAL_LANGFUSE_HOST = "http://localhost:3000"
 DEFAULT_LOCAL_LANGFUSE_PUBLIC_KEY = "publickey-local"
 DEFAULT_LOCAL_LANGFUSE_SECRET_KEY = "secretkey-local"

--- a/packages/exchange/src/exchange/langfuse_wrapper.py
+++ b/packages/exchange/src/exchange/langfuse_wrapper.py
@@ -19,9 +19,11 @@ import sys
 from io import StringIO
 from functools import cache, wraps  # Add this import
 
-DEFAULT_LOCAL_LANGFUSE_HOST = 'http://localhost:3000'
-DEFAULT_LOCAL_LANGFUSE_PUBLIC_KEY = 'publickey-local'
-DEFAULT_LOCAL_LANGFUSE_SECRET_KEY =  'secretkey-local'
+DEFAULT_LOCAL_LANGFUSE_HOST = "http://localhost:3000"
+DEFAULT_LOCAL_LANGFUSE_PUBLIC_KEY = "publickey-local"
+DEFAULT_LOCAL_LANGFUSE_SECRET_KEY = "secretkey-local"
+
+
 @cache
 def auth_check() -> bool:
     # Temporarily redirect stdout and stderr to suppress print statements from Langfuse
@@ -29,9 +31,9 @@ def auth_check() -> bool:
     sys.stderr = temp_stderr
 
     # Set environment variables if not specified
-    os.environ.setdefault('LANGFUSE_PUBLIC_KEY', DEFAULT_LOCAL_LANGFUSE_PUBLIC_KEY)
-    os.environ.setdefault('LANGFUSE_SECRET_KEY', DEFAULT_LOCAL_LANGFUSE_SECRET_KEY)
-    os.environ.setdefault('LANGFUSE_HOST', DEFAULT_LOCAL_LANGFUSE_HOST)
+    os.environ.setdefault("LANGFUSE_PUBLIC_KEY", DEFAULT_LOCAL_LANGFUSE_PUBLIC_KEY)
+    os.environ.setdefault("LANGFUSE_SECRET_KEY", DEFAULT_LOCAL_LANGFUSE_SECRET_KEY)
+    os.environ.setdefault("LANGFUSE_HOST", DEFAULT_LOCAL_LANGFUSE_HOST)
 
     auth_val = langfuse_context.auth_check()
 

--- a/packages/exchange/src/exchange/langfuse_wrapper.py
+++ b/packages/exchange/src/exchange/langfuse_wrapper.py
@@ -14,45 +14,30 @@ Note:
 
 import os
 from typing import Callable
-from dotenv import load_dotenv
 from langfuse.decorators import langfuse_context
 import sys
 from io import StringIO
-from pathlib import Path
-from functools import wraps  # Add this import
+from functools import cache, wraps  # Add this import
 
-
-def find_package_root(start_path: Path, marker_file: str = "pyproject.toml") -> Path:
-    while start_path != start_path.parent:
-        if (start_path / marker_file).exists():
-            return start_path
-        start_path = start_path.parent
-    return None
-
-
+DEFAULT_LOCAL_LANGFUSE_HOST = 'http://localhost:3000'
+DEFAULT_LOCAL_LANGFUSE_PUBLIC_KEY = 'publickey-local'
+DEFAULT_LOCAL_LANGFUSE_SECRET_KEY =  'secretkey-local'
+@cache
 def auth_check() -> bool:
     # Temporarily redirect stdout and stderr to suppress print statements from Langfuse
     temp_stderr = StringIO()
     sys.stderr = temp_stderr
 
-    # Load environment variables
-    load_dotenv(LANGFUSE_ENV_FILE, override=True)
+    # Set environment variables if not specified
+    os.environ.setdefault('LANGFUSE_PUBLIC_KEY', DEFAULT_LOCAL_LANGFUSE_PUBLIC_KEY)
+    os.environ.setdefault('LANGFUSE_SECRET_KEY', DEFAULT_LOCAL_LANGFUSE_SECRET_KEY)
+    os.environ.setdefault('LANGFUSE_HOST', DEFAULT_LOCAL_LANGFUSE_HOST)
 
     auth_val = langfuse_context.auth_check()
 
     # Restore stderr
     sys.stderr = sys.__stderr__
     return auth_val
-
-
-CURRENT_DIR = Path(__file__).parent
-PACKAGE_ROOT = find_package_root(CURRENT_DIR)
-
-LANGFUSE_ENV_FILE = os.path.join(PACKAGE_ROOT, ".env.langfuse.local") if PACKAGE_ROOT else None
-HAS_LANGFUSE_CREDENTIALS = False
-load_dotenv(LANGFUSE_ENV_FILE, override=True)
-
-HAS_LANGFUSE_CREDENTIALS = auth_check()
 
 
 def observe_wrapper(*args, **kwargs) -> Callable:  # noqa
@@ -71,7 +56,7 @@ def observe_wrapper(*args, **kwargs) -> Callable:  # noqa
     """
 
     def _wrapper(fn: Callable) -> Callable:
-        if HAS_LANGFUSE_CREDENTIALS:
+        if auth_check():
 
             @wraps(fn)
             def wrapped_fn(*fargs, **fkwargs):  # noqa

--- a/packages/exchange/tests/test_langfuse_wrapper.py
+++ b/packages/exchange/tests/test_langfuse_wrapper.py
@@ -9,40 +9,38 @@ def mock_langfuse_context():
         yield mock
 
 
+@patch("exchange.langfuse_wrapper.auth_check", return_value=True)
 def test_function_is_wrapped(mock_langfuse_context):
-    with patch("exchange.langfuse_wrapper.auth_check") as mocked_auth_check:
-        mocked_auth_check.return_value = True
-        mock_observe = MagicMock(side_effect=lambda *args, **kwargs: lambda fn: fn)
-        mock_langfuse_context.observe = mock_observe
+    mock_observe = MagicMock(side_effect=lambda *args, **kwargs: lambda fn: fn)
+    mock_langfuse_context.observe = mock_observe
 
-        def original_function(x: int, y: int) -> int:
-            return x + y
+    def original_function(x: int, y: int) -> int:
+        return x + y
 
-        # test function before we decorate it with
-        # @observe_wrapper("arg1", kwarg1="kwarg1")
-        assert not hasattr(original_function, "__wrapped__")
+    # test function before we decorate it with
+    # @observe_wrapper("arg1", kwarg1="kwarg1")
+    assert not hasattr(original_function, "__wrapped__")
 
-        # ensure we args get passed along (e.g. @observe(capture_input=False, capture_output=False))
-        decorated_function = observe_wrapper("arg1", kwarg1="kwarg1")(original_function)
-        assert hasattr(decorated_function, "__wrapped__")
-        assert decorated_function.__wrapped__ is original_function, "Function is not properly wrapped"
+    # ensure we args get passed along (e.g. @observe(capture_input=False, capture_output=False))
+    decorated_function = observe_wrapper("arg1", kwarg1="kwarg1")(original_function)
+    assert hasattr(decorated_function, "__wrapped__")
+    assert decorated_function.__wrapped__ is original_function, "Function is not properly wrapped"
 
-        assert decorated_function(2, 3) == 5
-        mock_observe.assert_called_once()
-        mock_observe.assert_called_with("arg1", kwarg1="kwarg1")
+    assert decorated_function(2, 3) == 5
+    mock_observe.assert_called_once()
+    mock_observe.assert_called_with("arg1", kwarg1="kwarg1")
 
 
+@patch("exchange.langfuse_wrapper.auth_check", return_value=False)
 def test_function_is_not_wrapped(mock_langfuse_context):
-    with patch("exchange.langfuse_wrapper.auth_check") as mocked_auth_check:
-        mocked_auth_check.return_value = False
-        mock_observe = MagicMock(return_value=lambda f: f)
-        mock_langfuse_context.observe = mock_observe
+    mock_observe = MagicMock(return_value=lambda f: f)
+    mock_langfuse_context.observe = mock_observe
 
-        @observe_wrapper("arg1", kwarg1="kwarg1")
-        def hello() -> str:
-            return "Hello"
+    @observe_wrapper("arg1", kwarg1="kwarg1")
+    def hello() -> str:
+        return "Hello"
 
-        assert not hasattr(hello, "__wrapped__")
-        assert hello() == "Hello"
+    assert not hasattr(hello, "__wrapped__")
+    assert hello() == "Hello"
 
-        mock_observe.assert_not_called()
+    mock_observe.assert_not_called()

--- a/packages/exchange/tests/test_langfuse_wrapper.py
+++ b/packages/exchange/tests/test_langfuse_wrapper.py
@@ -9,9 +9,10 @@ def mock_langfuse_context():
         yield mock
 
 
-@patch("exchange.langfuse_wrapper.auth_check", return_value=True)
-def test_function_is_wrapped(mock_langfuse_context):
+@patch("exchange.langfuse_wrapper.auth_check")
+def test_function_is_wrapped(mock_auth_check, mock_langfuse_context):
     mock_observe = MagicMock(side_effect=lambda *args, **kwargs: lambda fn: fn)
+    mock_auth_check.return_value = True
     mock_langfuse_context.observe = mock_observe
 
     def original_function(x: int, y: int) -> int:
@@ -31,9 +32,10 @@ def test_function_is_wrapped(mock_langfuse_context):
     mock_observe.assert_called_with("arg1", kwarg1="kwarg1")
 
 
-@patch("exchange.langfuse_wrapper.auth_check", return_value=False)
-def test_function_is_not_wrapped(mock_langfuse_context):
+@patch("exchange.langfuse_wrapper.auth_check")
+def test_function_is_not_wrapped(mock_auth_check, mock_langfuse_context):
     mock_observe = MagicMock(return_value=lambda f: f)
+    mock_auth_check.return_value = False
     mock_langfuse_context.observe = mock_observe
 
     @observe_wrapper("arg1", kwarg1="kwarg1")

--- a/packages/exchange/tests/test_langfuse_wrapper.py
+++ b/packages/exchange/tests/test_langfuse_wrapper.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from exchange.langfuse_wrapper import observe_wrapper
 
+
 @pytest.fixture
 def mock_langfuse_context():
     with patch("exchange.langfuse_wrapper.langfuse_context") as mock:

--- a/packages/exchange/tests/test_langfuse_wrapper.py
+++ b/packages/exchange/tests/test_langfuse_wrapper.py
@@ -2,45 +2,46 @@ import pytest
 from unittest.mock import patch, MagicMock
 from exchange.langfuse_wrapper import observe_wrapper
 
-
 @pytest.fixture
 def mock_langfuse_context():
     with patch("exchange.langfuse_wrapper.langfuse_context") as mock:
         yield mock
 
 
-@patch("exchange.langfuse_wrapper.HAS_LANGFUSE_CREDENTIALS", True)
 def test_function_is_wrapped(mock_langfuse_context):
-    mock_observe = MagicMock(side_effect=lambda *args, **kwargs: lambda fn: fn)
-    mock_langfuse_context.observe = mock_observe
+    with patch("exchange.langfuse_wrapper.auth_check") as mocked_auth_check:
+        mocked_auth_check.return_value = True
+        mock_observe = MagicMock(side_effect=lambda *args, **kwargs: lambda fn: fn)
+        mock_langfuse_context.observe = mock_observe
 
-    def original_function(x: int, y: int) -> int:
-        return x + y
+        def original_function(x: int, y: int) -> int:
+            return x + y
 
-    # test function before we decorate it with
-    # @observe_wrapper("arg1", kwarg1="kwarg1")
-    assert not hasattr(original_function, "__wrapped__")
+        # test function before we decorate it with
+        # @observe_wrapper("arg1", kwarg1="kwarg1")
+        assert not hasattr(original_function, "__wrapped__")
 
-    # ensure we args get passed along (e.g. @observe(capture_input=False, capture_output=False))
-    decorated_function = observe_wrapper("arg1", kwarg1="kwarg1")(original_function)
-    assert hasattr(decorated_function, "__wrapped__")
-    assert decorated_function.__wrapped__ is original_function, "Function is not properly wrapped"
+        # ensure we args get passed along (e.g. @observe(capture_input=False, capture_output=False))
+        decorated_function = observe_wrapper("arg1", kwarg1="kwarg1")(original_function)
+        assert hasattr(decorated_function, "__wrapped__")
+        assert decorated_function.__wrapped__ is original_function, "Function is not properly wrapped"
 
-    assert decorated_function(2, 3) == 5
-    mock_observe.assert_called_once()
-    mock_observe.assert_called_with("arg1", kwarg1="kwarg1")
+        assert decorated_function(2, 3) == 5
+        mock_observe.assert_called_once()
+        mock_observe.assert_called_with("arg1", kwarg1="kwarg1")
 
 
-@patch("exchange.langfuse_wrapper.HAS_LANGFUSE_CREDENTIALS", False)
 def test_function_is_not_wrapped(mock_langfuse_context):
-    mock_observe = MagicMock(return_value=lambda f: f)
-    mock_langfuse_context.observe = mock_observe
+    with patch("exchange.langfuse_wrapper.auth_check") as mocked_auth_check:
+        mocked_auth_check.return_value = False
+        mock_observe = MagicMock(return_value=lambda f: f)
+        mock_langfuse_context.observe = mock_observe
 
-    @observe_wrapper("arg1", kwarg1="kwarg1")
-    def hello() -> str:
-        return "Hello"
+        @observe_wrapper("arg1", kwarg1="kwarg1")
+        def hello() -> str:
+            return "Hello"
 
-    assert not hasattr(hello, "__wrapped__")
-    assert hello() == "Hello"
+        assert not hasattr(hello, "__wrapped__")
+        assert hello() == "Hello"
 
-    mock_observe.assert_not_called()
+        mock_observe.assert_not_called()


### PR DESCRIPTION
**What**
Currently the env.langfuse.local is used for 2 purposes:

1. Start the langfuse server on localhost
2. The host, public key, private key is used in goose application as a langfuse client to send tracing data.

For item 2, it would be better to specify the values on the goose client side (user) instead of packaging into the exchange package, either via loading an environment file that user specifies the path or loading the environment variable that user sets.

**What**
In exchange, rendering the environment variables for langfuse host, public key, private key, if any of them does not exists, fallback to the default variable for localhost langfuse

